### PR TITLE
Some fixes

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/LegacyMigrator.java
+++ b/src/main/java/ru/timeconqueror/lootgames/LegacyMigrator.java
@@ -78,10 +78,10 @@ public class LegacyMigrator {
 
         int rounds = legacyGol.StartDigits;
         Configuration cfgRewards = LGConfigs.REWARDS.getConfig();
-        rounds = processStageConfig(rounds, legacyGol.GameStageI, cfgGol.getCategory(LGConfigs.GOL.stage1.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage1().getCategoryName()));
-        rounds = processStageConfig(rounds, legacyGol.GameStageII, cfgGol.getCategory(LGConfigs.GOL.stage2.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage2().getCategoryName()));
-        rounds = processStageConfig(rounds, legacyGol.GameStageIII, cfgGol.getCategory(LGConfigs.GOL.stage3.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage3().getCategoryName()));
-        processStageConfig(rounds, legacyGol.GameStageIV, cfgGol.getCategory(LGConfigs.GOL.stage4.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage4().getCategoryName()));
+        rounds = processStageConfig(rounds, legacyGol.GameStageI, cfgGol.getCategory(LGConfigs.GOL.stage1.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage1().getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsMinesweeper.getStage1().getCategoryName()));
+        rounds = processStageConfig(rounds, legacyGol.GameStageII, cfgGol.getCategory(LGConfigs.GOL.stage2.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage2().getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsMinesweeper.getStage2().getCategoryName()));
+        rounds = processStageConfig(rounds, legacyGol.GameStageIII, cfgGol.getCategory(LGConfigs.GOL.stage3.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage3().getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsMinesweeper.getStage3().getCategoryName()));
+        processStageConfig(rounds, legacyGol.GameStageIV, cfgGol.getCategory(LGConfigs.GOL.stage4.getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsGol.getStage4().getCategoryName()), cfgRewards.getCategory(LGConfigs.REWARDS.rewardsMinesweeper.getStage4().getCategoryName()));
 
         LOGGER.info("Successfully migrated old config file!");
 
@@ -89,16 +89,21 @@ public class LegacyMigrator {
         LOGGER.info("Configs reloaded!");
     }
 
-    private static int processStageConfig(int startDigits, LegacyLGConfig.LootStageConfig legacyStage, ConfigCategory catStage, ConfigCategory catRew) {
+    private static int processStageConfig(int startDigits, LegacyLGConfig.LootStageConfig legacyStage, ConfigCategory catStage, ConfigCategory catGolRewards, ConfigCategory catMsRewards) {
         int roundsStage2 = Math.max(legacyStage.MinDigitsRequired - startDigits, 1);
         catStage.get(ConfigGOL.Names.ROUNDS).set(roundsStage2);
         catStage.get(ConfigGOL.Names.RANDOMIZE_SEQUENCE).set(legacyStage.RandomizeSequence);
         catStage.get(ConfigGOL.Names.DISPLAY_TIME).set(legacyStage.DisplayTime * 20 / 1000);
 
-        catRew.get(RewardConfig.Names.MIN_ITEMS).set(legacyStage.MinItems);
-        catRew.get(RewardConfig.Names.MAX_ITEMS).set(legacyStage.MaxItems);
-        catRew.get(RewardConfig.Names.DEFAULT_LOOT_TABLE).set(legacyStage.LootTable);
-        catRew.get(RewardConfig.Names.PER_DIM_CONFIGS).set(legacyStage.DimensionalLoots.entrySet().stream().map(e -> e.getKey() + "|" + e.getValue().LootTable).toArray(String[]::new));
+        catGolRewards.get(RewardConfig.Names.MIN_ITEMS).set(legacyStage.MinItems);
+        catGolRewards.get(RewardConfig.Names.MAX_ITEMS).set(legacyStage.MaxItems);
+        catGolRewards.get(RewardConfig.Names.DEFAULT_LOOT_TABLE).set(legacyStage.LootTable);
+        catGolRewards.get(RewardConfig.Names.PER_DIM_CONFIGS).set(legacyStage.DimensionalLoots.entrySet().stream().map(e -> e.getKey() + "|" + e.getValue().LootTable).toArray(String[]::new));
+
+        catMsRewards.get(RewardConfig.Names.MIN_ITEMS).set(legacyStage.MinItems);
+        catMsRewards.get(RewardConfig.Names.MAX_ITEMS).set(legacyStage.MaxItems);
+        catMsRewards.get(RewardConfig.Names.DEFAULT_LOOT_TABLE).set(legacyStage.LootTable);
+        catMsRewards.get(RewardConfig.Names.PER_DIM_CONFIGS).set(legacyStage.DimensionalLoots.entrySet().stream().map(e -> e.getKey() + "|" + e.getValue().LootTable).toArray(String[]::new));
 
         return legacyStage.MinDigitsRequired;
     }

--- a/src/main/java/ru/timeconqueror/lootgames/api/util/RewardUtils.java
+++ b/src/main/java/ru/timeconqueror/lootgames/api/util/RewardUtils.java
@@ -44,7 +44,7 @@ public class RewardUtils {
             for (HorizontalDirection direction : HorizontalDirection.values()) {
                 if (counter >= rewardLevel) break;
 
-                spawnLootChest(world, centralPos, direction, SpawnChestData.fromRewardConfig(game, rewardConfig.getStageByIndex(rewardLevel - 1)));
+                spawnLootChest(world, centralPos, direction, SpawnChestData.fromRewardConfig(game, rewardConfig.getStageByIndex(counter)));
                 counter++;
             }
         }

--- a/src/main/java/ru/timeconqueror/lootgames/common/config/ConfigMS.java
+++ b/src/main/java/ru/timeconqueror/lootgames/common/config/ConfigMS.java
@@ -108,7 +108,7 @@ public class ConfigMS extends Config {
         private final int boardRadius;
         private final int bombCount;
 
-        public DefaultData(int boardRadius, int bombCount) {
+        private DefaultData(int boardRadius, int bombCount) {
             this.boardRadius = boardRadius;
             this.bombCount = bombCount;
         }
@@ -120,7 +120,7 @@ public class ConfigMS extends Config {
         private final StageSnapshot stage3;
         private final StageSnapshot stage4;
 
-        public Snapshot(StageSnapshot stage1, StageSnapshot stage2, StageSnapshot stage3, StageSnapshot stage4) {
+        private Snapshot(StageSnapshot stage1, StageSnapshot stage2, StageSnapshot stage3, StageSnapshot stage4) {
             this.stage1 = stage1;
             this.stage2 = stage2;
             this.stage3 = stage3;
@@ -145,6 +145,10 @@ public class ConfigMS extends Config {
             );
         }
 
+        public static Snapshot stub() {
+            return new Snapshot(StageSnapshot.stub(), StageSnapshot.stub(), StageSnapshot.stub(), StageSnapshot.stub());
+        }
+
         public StageSnapshot getStage1() {
             return stage1;
         }
@@ -165,7 +169,7 @@ public class ConfigMS extends Config {
             private final int bombCount;
             private final int boardSize;
 
-            public StageSnapshot(int bombCount, int boardSize) {
+            private StageSnapshot(int bombCount, int boardSize) {
                 this.bombCount = bombCount;
                 this.boardSize = boardSize;
             }
@@ -185,8 +189,12 @@ public class ConfigMS extends Config {
                 return compound;
             }
 
-            public static StageSnapshot deserialize(NBTTagCompound nbt) {
+            private static StageSnapshot deserialize(NBTTagCompound nbt) {
                 return new StageSnapshot(nbt.getInteger("bomb_count"), nbt.getInteger("board_size"));
+            }
+
+            private static StageSnapshot stub() {
+                return new StageSnapshot(0, 0);
             }
         }
 

--- a/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
+++ b/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
@@ -12,6 +12,7 @@ import ru.timeconqueror.lootgames.api.minigame.NotifyColor;
 import ru.timeconqueror.lootgames.api.task.TaskCreateExplosion;
 import ru.timeconqueror.lootgames.api.util.Pos2i;
 import ru.timeconqueror.lootgames.api.util.RewardUtils;
+import ru.timeconqueror.lootgames.common.config.ConfigMS;
 import ru.timeconqueror.lootgames.common.config.ConfigMS.Snapshot;
 import ru.timeconqueror.lootgames.common.config.LGConfigs;
 import ru.timeconqueror.lootgames.common.packet.game.SPMSFieldChanged;
@@ -41,8 +42,6 @@ import static ru.timeconqueror.timecore.api.util.NetworkUtils.getPlayersNearby;
 //TODO if all non-bomb fields are revealed, finish the game
 //TODO remove interact with opened fields
 public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
-    public static final String ADV_BEAT_LEVEL4 = "ms_level_4";
-
     public boolean cIsGenerated;
 
     private int currentLevel = 1;
@@ -63,11 +62,6 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
         board = new MSBoard(0, 0);
     }
 
-    public static Pos2i convertToGamePos(BlockPos masterPos, BlockPos subordinatePos) {
-        BlockPos temp = subordinatePos.subtract(masterPos);
-        return new Pos2i(temp.getX(), temp.getZ());
-    }
-
     // server only
     public void setConfigSnapshot(Snapshot configSnapshot) {
         this.configSnapshot = configSnapshot;
@@ -84,6 +78,15 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
         }
 
         super.onPlace();
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+
+        if (isClientSide()) {
+            configSnapshot = ConfigMS.Snapshot.stub(); // needs for first client ticks, because the config from readNBT is called a little bit later
+        }
     }
 
     public boolean isBoardGenerated() {


### PR DESCRIPTION
Fixed:
- Rewards are the same in all chests
- Crash on first client tick when load the world being in a chunk with minesweeper.
- Old config now changes Minesweeper rewards as well.

ATTENTION for GTNH: If some worlds have already been launched with LootGames 2.0, change your minesweeper rewards in config manually: it needs to be the same as game of light's rewards!