### PR TITLE
Allow specifying weights for different games

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/common/config/ConfigGOL.java
+++ b/src/main/java/ru/timeconqueror/lootgames/common/config/ConfigGOL.java
@@ -7,6 +7,8 @@ import ru.timeconqueror.timecore.api.common.config.ConfigSection;
 import java.util.EnumSet;
 
 public class ConfigGOL extends Config {
+    public int weight;
+
     public int startDigitAmount;
     public int attemptCount;
     public int expandFieldAtStage;
@@ -30,6 +32,8 @@ public class ConfigGOL extends Config {
 
     @Override
     public void init() {
+        weight = config.getInt("weight", getKey(), 1, 0, Integer.MAX_VALUE, "How likely this game is chosen compared to other games. The higher this value is, the more likely this game is chosen. Set to 0 to turn this off.");
+
         startDigitAmount = config.getInt(Names.START_DIGIT_AMOUNT, getKey(), 2, 1, Integer.MAX_VALUE, "Regulates how many digits should be randomly chosen and shown at game-start.");
         attemptCount = config.getInt(Names.ATTEMPT_COUNT, getKey(), 3, 1, Integer.MAX_VALUE, "It represents the number of attempts the player has to beat the game successfully.");
         expandFieldAtStage = config.getInt(Names.EXPAND_FIELD_AT_STAGE, getKey(), 2, 0, 4, "At which stage should the playfield become a full 3x3 pattern?\nSet 0 to disable and keep the 4-block size; set 1 to always start with 3x3.");

--- a/src/main/java/ru/timeconqueror/lootgames/common/config/ConfigMS.java
+++ b/src/main/java/ru/timeconqueror/lootgames/common/config/ConfigMS.java
@@ -10,6 +10,8 @@ import ru.timeconqueror.timecore.api.common.config.ConfigSection;
 public class ConfigMS extends Config {
     private static final String NO_CHANGE_FOR_GENERATED = "Won't be changed for already generated Minesweeper boards!";
 
+    public int weight;
+
     public int detonationTime;
     public int attemptCount;
 
@@ -28,6 +30,8 @@ public class ConfigMS extends Config {
 
     @Override
     public void init() {
+        weight = config.getInt("weight", getKey(), 1, 0, Integer.MAX_VALUE, "How likely this game is chosen compared to other games. The higher this value is, the more likely this game is chosen. Set to 0 to turn this off.");
+
         detonationTime = config.getInt("detonation_time", getKey(), 3 * 20, 0, 600, "The time until bombs start to explode. Represented in ticks.");
         attemptCount = config.getInt("attempt_count", getKey(), 3, 1, Integer.MAX_VALUE, "It represents the number of attempts the player has to beat the game successfully.");
 

--- a/src/main/java/ru/timeconqueror/lootgames/registry/LGGames.java
+++ b/src/main/java/ru/timeconqueror/lootgames/registry/LGGames.java
@@ -2,6 +2,7 @@ package ru.timeconqueror.lootgames.registry;
 
 import ru.timeconqueror.lootgames.api.LootGamesAPI;
 import ru.timeconqueror.lootgames.api.task.TaskCreateExplosion;
+import ru.timeconqueror.lootgames.common.config.LGConfigs;
 import ru.timeconqueror.lootgames.minigame.gol.GameOfLight;
 import ru.timeconqueror.lootgames.minigame.minesweeper.GameMineSweeper;
 
@@ -10,7 +11,9 @@ public class LGGames {
     public static void register() {
         LootGamesAPI.registerTaskFactory(TaskCreateExplosion.class, TaskCreateExplosion::new);
 
-        LootGamesAPI.registerGameGenerator(new GameOfLight.Factory());
-        LootGamesAPI.registerGameGenerator(new GameMineSweeper.Factory());
+        for (int i = 0; i < LGConfigs.GOL.weight; i++)
+            LootGamesAPI.registerGameGenerator(new GameOfLight.Factory());
+        for (int i = 0; i < LGConfigs.MINESWEEPER.weight; i++)
+            LootGamesAPI.registerGameGenerator(new GameMineSweeper.Factory());
     }
 }


### PR DESCRIPTION
This is mainly for server owners that wish to tweak the game to their preference. In the standard zip file we distribute it should remain the same as before, i.e. 50-50 split between GOL and minesweeper.