### PR TITLE
Don't throw IllegalStateException

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
+++ b/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
@@ -317,7 +317,6 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
                 }
 
                 int bombsAround = board.getType(mainPos).getId();
-                if (bombsAround < 1) throw new IllegalStateException();
 
                 int marked = 0;
                 for (int x = -1; x <= 1; x++) {


### PR DESCRIPTION
Fixes a server-side exception being thrown when player shift right-clicking on an empty subordinate.
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11061