### PR TITLE
Fix NPE on neighbors reveal

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
+++ b/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
@@ -341,7 +341,7 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
                     }
 
                     Pos2i pos = mainPos.add(x, y);
-                    if (board.hasFieldOn(pos) && board.isHidden(pos)) {
+                    if (isBoardGenerated() && board.hasFieldOn(pos) && board.isHidden(pos)) {
                         if (revealMarked || board.getMark(pos) != Mark.FLAG) {
                             revealField(player, pos);
                         }


### PR DESCRIPTION
```
java.lang.NullPointerException
        at ru.timeconqueror.lootgames.minigame.minesweeper.MSBoard.getField(MSBoard.java:127) ~[MSBoard.class:?]
        at ru.timeconqueror.lootgames.minigame.minesweeper.MSBoard.isHidden(MSBoard.java:53) ~[MSBoard.class:?]
        at ru.timeconqueror.lootgames.minigame.minesweeper.GameMineSweeper$StageWaiting.revealAllNeighbours(GameMineSweeper.java:345) ~[GameMineSweeper$StageWaiting.class:?]
        at ru.timeconqueror.lootgames.minigame.minesweeper.GameMineSweeper$StageWaiting.onClick(GameMineSweeper.java:268) ~[GameMineSweeper$StageWaiting.class:?]
```
Board is being regenerated in the middle of revealing neighbors.