### PR TITLE
fix: minesweeper crash on win

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
+++ b/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
@@ -319,6 +319,10 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
 
                 save();
 
+                // If another revealField call within revealAllNeighbors already ran the win check,
+                // the board might already be reset
+                if (!board.isGenerated()) return;
+
                 if (board.checkWin()) {
                     onLevelSuccessfullyFinished();
                 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11609, Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11763

Probably fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14714
(Does not match the description exactly but the conditions are very close and the crash log would match)

Winning by revealing a tile that has 0 mines nearby which then reveals its neighbors causes a crash
- [`revealField`](https://github.com/GTNewHorizons/LootGames/blob/master/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java#L296-L326)(1) will call `revealAllNeighbours` to  reveal all neighbors since it's a 0-mine field
- [`revealAllNeighbours`](https://github.com/GTNewHorizons/LootGames/blob/master/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java#L328-L354) will call `revealField`(2) on each unrevealed neighbor
- `revealField`(2) will call [`checkWin`](https://github.com/GTNewHorizons/LootGames/blob/e76544a87a057bc314398e9865c983f6387edf38/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/MSBoard.java#L105-L125). For the last field, this will return true and `onLevelSuccessfullyFinished` is called
  - `onLevelSuccessfullyFinished` also sets `MSBoard.board` to null until the next level is generated
- After `revealAllNeighbors`, `revealField`(1) will continue and call `checkWin` as its last action.
  - Since `onLevelSuccessfullyFinished`->`revealField`(2) has already marked the level as finished, `MSBoard.board` is now null, so `checkWin` runs into a Null Pointer Exception

Before:

https://github.com/user-attachments/assets/367419ed-3e00-4742-8a06-ce3316797b01

After:

https://github.com/user-attachments/assets/c06af990-bd14-4c23-abcd-44606a7d9bc1




