### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/lootgames/lang/en_US.lang
+++ b/src/main/resources/assets/lootgames/lang/en_US.lang
@@ -2,6 +2,7 @@ itemGroup.LootGames=Loot Games
 
 tile.chessGame.name=Chess
 tile.lightGame.name=Game of Light
+tile.dungeonBrick.name=Dungeon Block
 tile.dungeonBrick_0.name=Dungeon Wall
 tile.dungeonBrick_1.name=Dungeon Ceiling
 tile.dungeonBrick_2.name=Dungeon Floor
@@ -9,6 +10,7 @@ tile.dungeonBrick_3.name=Cracked Dungeon Wall
 tile.dungeonBrick_4.name=Cracked Dungeon Ceiling
 tile.dungeonBrick_5.name=Cracked Dungeon Floor
 tile.dungeonBrick_6.name=Shielded Dungeon Floor
+tile.dungeonLight.name=Dungeon Lamp
 tile.dungeonLight_0.name=Dungeon Lamp
 tile.dungeonLight_1.name=Broken Dungeon Lamp
 


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.