### PR TITLE
Fix duplicate loot generation in Minesweeper Level 4

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
+++ b/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
@@ -120,7 +120,7 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
             currentLevel++;
 
             saveAndSync();
-        } else {
+        } else if (currentLevel == 4) {
             currentLevel++;
             triggerGameWin();
         }


### PR DESCRIPTION
Fixed a bug where players could receive multiples times the loot of completing Minesweeper Level 4 via a recursive chain reaction

Fixes GTNewHorizons/GT-New-Horizons-Modpack#17740