### PR TITLE
Fix duplicate loot generation in Minesweeper Level 4 (#25) for 2.8

### DIFF
--- a/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
+++ b/src/main/java/ru/timeconqueror/lootgames/minigame/minesweeper/GameMineSweeper.java
@@ -120,7 +120,7 @@ public class GameMineSweeper extends BoardLootGame<GameMineSweeper> {
             currentLevel++;
 
             saveAndSync();
-        } else {
+        } else if (currentLevel == 4) {
             currentLevel++;
             triggerGameWin();
         }


### PR DESCRIPTION
Cherry of https://github.com/GTNewHorizons/LootGames/pull/25