### PR TITLE
Fix loot games not syncing in CC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,7 @@ apiPackage =
 # Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
 # There can be multiple files in a space-separated list.
 # Example value: mymodid_at.cfg nei_at.cfg
-accessTransformersFile = lootgames_at.cfg
+accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = false

--- a/src/main/java/ru/timeconqueror/lootgames/utils/Trackers.java
+++ b/src/main/java/ru/timeconqueror/lootgames/utils/Trackers.java
@@ -10,14 +10,10 @@ public class Trackers {
 
     public static void forPlayersWatchingChunk(WorldServer world, int x, int z, Consumer<EntityPlayerMP> action) {
         PlayerManager playerManager = world.getPlayerManager();
-        PlayerManager.PlayerInstance instance = playerManager.getOrCreateChunkWatcher(x, z, false);
-
-        if (instance != null) {
-            for (Object o : instance.playersWatchingChunk) {
-                EntityPlayerMP player = (EntityPlayerMP) o;
-                if (!player.loadedChunks.contains(instance.chunkLocation)) {
-                    action.accept(player);
-                }
+        for (Object o : world.playerEntities) {
+            EntityPlayerMP player = (EntityPlayerMP) o;
+            if (playerManager.isPlayerWatchingChunk(player, x, z)) {
+                action.accept(player);
             }
         }
     }

--- a/src/main/resources/META-INF/lootgames_at.cfg
+++ b/src/main/resources/META-INF/lootgames_at.cfg
@@ -1,5 +1,0 @@
-public net.minecraft.server.management.PlayerManager$PlayerInstance
-
-public net.minecraft.server.management.PlayerManager func_72690_a(IIZ)Lnet/minecraft/server/management/PlayerManager$PlayerInstance;
-public net.minecraft.server.management.PlayerManager$PlayerInstance field_73263_b
-public net.minecraft.server.management.PlayerManager$PlayerInstance field_73264_c


### PR DESCRIPTION
## Summary
Loot Games previously used internal fields in PlayerManagers to sync their state to players. CC doesn't replicate this logic, so it silently broke. CC does, however, implement isPlayerWatchingChunk, so this PR instead loops over all players in the given world and checks if they're watching the given chunk. It then sends the update packets to whoever is viewing the chunk containing the loot game.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
